### PR TITLE
add wiki as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs"]
+	path = docs
+	url = https://github.com/m-lab/piecewise-saas.wiki.git


### PR DESCRIPTION
This PR adds the repo wiki as a sub-module. Wiki has been pre-populated with documentation.